### PR TITLE
Fix migration file

### DIFF
--- a/softdelete/migrations/0001_initial.py
+++ b/softdelete/migrations/0001_initial.py
@@ -8,7 +8,7 @@ import django.utils.timezone
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('contenttypes', '0002_remove_content_type_name'),
+        ('contenttypes', '0001_initial'),
     ]
 
     operations = [
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created_date', models.DateTimeField(default=django.utils.timezone.now)),
-                ('object_id', models.PositiveIntegerField()),
+                ('object_id', models.CharField(max_length=100)),
                 ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
             ],
         ),
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created_date', models.DateTimeField(default=django.utils.timezone.now)),
-                ('object_id', models.PositiveIntegerField()),
+                ('object_id', models.CharField(max_length=100)),
                 ('changeset', models.ForeignKey(related_name='soft_delete_records', to='softdelete.ChangeSet')),
                 ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
             ],


### PR DESCRIPTION
The migrations file had as a dependency a migration file added in Django 1.8 and also has incorrect object_id fields (Integers instead of CharFields).  This diff fixes those two issues.

Tested end to end
